### PR TITLE
Removed ei- prefix in Rails and Sinatra

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Next, you have to render the evil-icons sprite in your template (or, in your lay
 Finally, you can render the icon using the `evil_icon` helper.
 Here are some examples:
 ```erb
-<%= evil_icon 'ei-search' %>
-<%= evil_icon 'ei-arrow-right', size: :m %>
-<%= evil_icon 'ei-envelope', size: :l, class: "custom-class" %>
+<%= evil_icon 'search' %>
+<%= evil_icon 'arrow-right', size: :m %>
+<%= evil_icon 'envelope', size: :l, class: "custom-class" %>
 ```
 
 
@@ -116,9 +116,9 @@ Next, you have to render the evil-icons sprite in your template (or, in your lay
 Finally, you can render the icon using the `evil_icon` helper.
 Here are some examples:
 ```erb
-<%= evil_icon 'ei-search' %>
-<%= evil_icon 'ei-arrow-right', size: :m %>
-<%= evil_icon 'ei-envelope', size: :l, class: "custom-class" %>
+<%= evil_icon 'search' %>
+<%= evil_icon 'arrow-right', size: :m %>
+<%= evil_icon 'envelope', size: :l, class: "custom-class" %>
 ```
 
 In order to use the stylesheets, you have to add Sprockets to your application.

--- a/lib/evil_icons/helpers.rb
+++ b/lib/evil_icons/helpers.rb
@@ -6,7 +6,8 @@ module EvilIcons
     end
 
     def evil_icon(name, options = {})
-      size  = options[:size] ? "icon--#{options[:size]}" : ''
+      name = "ei-#{name}" unless name.include?('ei-')
+      size = options[:size] ? "icon--#{options[:size]}" : ''
       options[:class] = "icon icon--#{name} #{size} #{options[:class]}"
 
       icon = "<svg class='icon__cnt'><use xlink:href='##{name}-icon'/></svg>"


### PR DESCRIPTION
Removed 'ei-' prefix in evil_icon method. Old syntax is supported